### PR TITLE
Add support for external webserver

### DIFF
--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -5,10 +5,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-static def getCommitHash() {
-    'git rev-parse --verify --short HEAD'.execute().text.trim()
-}
-
 dependencies {
     implementation project(':DynmapCoreAPI')
     implementation 'javax.servlet:javax.servlet-api:3.1'
@@ -40,7 +36,7 @@ processResources {
     ]) {
         // replace version and mcversion
         expand(
-                buildnumber: getCommitHash(),
+                buildnumber: '0',
                 version: project.version
         )
     }

--- a/DynmapCore/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
+++ b/DynmapCore/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
@@ -11,6 +11,7 @@ import org.json.simple.parser.ParseException;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -37,7 +38,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
     private long last_confighash;
     private MessageDigest md;
     private MapStorage storage;
-    private File baseStandaloneDir;
+    private File web_dir;
 
     private static class FileToWrite {
         String filename;
@@ -126,10 +127,11 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
         chat_perms = configuration.getBoolean("webchat-permissions", false);
         lengthlimit = configuration.getInteger("chatlengthlimit", 256);
         storage = core.getDefaultMapStorage();
-        baseStandaloneDir = new File(core.configuration.getString("webpath", "web"), "standalone");
-        if (!baseStandaloneDir.isAbsolute()) {
-            baseStandaloneDir = new File(core.getDataFolder(), baseStandaloneDir.toString());
-        }
+
+        web_dir = new File(core.configuration.getString("webpath", "web"), "standalone");
+        if (!web_dir.isAbsolute())
+            web_dir = new File(core.getDataFolder(), web_dir.toString());
+
         try {
             md = MessageDigest.getInstance("SHA-1");
         } catch (NoSuchAlgorithmException nsax) {
@@ -271,7 +273,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
                     os.write(outputBytes);
                     core.getDefaultMapStorage().setStaticWebFile("standalone/config.js", os);
                 } else {
-                    File f = new File(baseStandaloneDir, "config.js");
+                    File f = new File(web_dir, "config.js");
                     FileOutputStream fos = null;
                     try {
                         fos = new FileOutputStream(f);

--- a/DynmapCore/src/main/java/org/dynmap/storage/MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/MapStorage.java
@@ -7,6 +7,7 @@ import org.dynmap.utils.BufferOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.zip.CRC32;
@@ -40,7 +41,7 @@ public abstract class MapStorage {
      * @return true if success
      */
     public boolean init(DynmapCore core) {
-        baseStandaloneDir = new File(core.configuration.getString("webpath", "web"), "standalone");
+        baseStandaloneDir = new File(core.configuration.getString("dynmap_web", "web"), "standalone");
         if (!baseStandaloneDir.isAbsolute()) {
             baseStandaloneDir = new File(core.getDataFolder(), baseStandaloneDir.toString());
         }
@@ -251,11 +252,16 @@ public abstract class MapStorage {
      * @param core - core object
      */
     public void addPaths(StringBuilder sb, DynmapCore core) {
-        String p = core.getFile(core.getWebPath()).getAbsolutePath();
-        if (!p.endsWith("/"))
-            p += "/";
+        var path = Paths.get(core.configuration.getString("serve_web", "web"));
+        if (!path.isAbsolute())
+            path = core.getDataFolder().toPath().resolve(path);
+
+        var pathStr = path.toString();
+
+        if (!pathStr.endsWith("/"))
+            pathStr += "/";
         sb.append("$webpath = \'");
-        sb.append(WebAuthManager.esc(p));
+        sb.append(WebAuthManager.esc(pathStr));
         sb.append("\';\n");
     }
 

--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -27,6 +27,7 @@ import org.dynmap.utils.BufferOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -646,7 +647,7 @@ public class AWSS3MapStorage extends MapStorage {
 
     @Override
     public void addPaths(StringBuilder sb, DynmapCore core) {
-        String p = core.getTilesFolder().getAbsolutePath();
+        String p = Path.of(core.getServeTilesPath()).toAbsolutePath().toString();
         if (!p.endsWith("/"))
             p += "/";
         sb.append("$tilespath = \'");

--- a/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
@@ -14,6 +14,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -244,7 +245,7 @@ public class FileTreeMapStorage extends MapStorage {
         if (!super.init(core)) {
             return false;
         }
-        baseTileDir = core.getTilesFolder();
+        baseTileDir = core.getDynmapTileDirectory();
         hashmap = new TileHashManager(baseTileDir, true);
         return true;
     }
@@ -684,7 +685,7 @@ public class FileTreeMapStorage extends MapStorage {
 
     @Override
     public void addPaths(StringBuilder sb, DynmapCore core) {
-        String p = core.getTilesFolder().getAbsolutePath();
+        String p = Path.of(core.getServeTilesPath()).toAbsolutePath().toString();
         if (!p.endsWith("/"))
             p += "/";
         sb.append("$tilespath = \'");

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,8 @@ plugins {
     id 'maven-publish'
 }
 
-apply plugin: 'eclipse'
-
-eclipse {
-    project {
-        name = "Dynmap"
-    }
+static def getCommitHash() {
+    'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
 allprojects {
@@ -41,8 +37,7 @@ allprojects {
     apply plugin: 'java'
 
     group = 'us.dynmap'
-    version = '3.7-beta-7'
-
+    version = getCommitHash()
 }
 
 java {

--- a/fabric-1.21.1/build.gradle
+++ b/fabric-1.21.1/build.gradle
@@ -55,7 +55,7 @@ jar {
 }
 
 remapJar {
-    archiveFileName = "Dynmap-${project.version}-fabric-${project.minecraft_version}.jar"
+    archiveFileName = "Dynmap-fabric-${project.minecraft_version}-${project.version}.jar"
     destinationDirectory = file '../target'
 }
 

--- a/fabric-1.21.1/src/main/resources/configuration.txt
+++ b/fabric-1.21.1/src/main/resources/configuration.txt
@@ -324,10 +324,16 @@ render-triggers:
 #webpage-title: "My Awesome Server Map"
 
 # The path where the tile-files are placed.
-tilespath: web/tiles
+#dynmap_tiles: /mnt/bulk_storage
 
-# The path where the web-files are located.
-webpath: web
+# The path where the website finds tile files.
+#serve_tiles: /mnt/bulk_storage
+
+# Where dynmap should write web files and web config.
+#dynmap_web: /mnt/remote_webserver_www_mount
+
+# Where the website should search for web files and web config.
+#serve_web: /var/www/html/minecraft
 
 # If set to false, disable extraction of webpath content (good if using custom web UI or 3rd party web UI)
 # Note: web interface is unsupported in this configuration - you're on your own

--- a/forge-1.21/build.gradle
+++ b/forge-1.21/build.gradle
@@ -9,12 +9,6 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle'
 
-eclipse {
-    project {
-        name = "Dynmap(Forge-1.21)"
-    }
-}
-
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
 ext.buildNumber = System.getenv().BUILD_NUMBER ?: "Dev"
@@ -43,7 +37,7 @@ processResources
             filesMatching('META-INF/mods.toml') {
                 // replace version and mcversion
                 expand(
-                        version: project.version + '-' + project.ext.buildNumber,
+                        version: project.version,
                         mcversion: "1.21"
                 )
             }

--- a/forge-1.21/src/main/resources/configuration.txt
+++ b/forge-1.21/src/main/resources/configuration.txt
@@ -327,10 +327,16 @@ render-triggers:
 #webpage-title: "My Awesome Server Map"
 
 # The path where the tile-files are placed.
-tilespath: web/tiles
+#dynmap_tiles: /mnt/bulk_storage
 
-# The path where the web-files are located.
-webpath: web
+# The path where the website finds tile files.
+#serve_tiles: /mnt/bulk_storage
+
+# Where dynmap should write web files and web config.
+#dynmap_web: /mnt/remote_webserver_www_mount
+
+# Where the website should search for web files and web config.
+#serve_web: /var/www/html/minecraft
 
 # If set to false, disable extraction of webpath content (good if using custom web UI or 3rd party web UI)
 # Note: web interface is unsupported in this configuration - you're on your own


### PR DESCRIPTION
Previously directory paths had to be identical for web server and minecraft server, effectively limiting "external" hosting to being on the same system as dynmap was being hosted on.